### PR TITLE
Static placeholder publication for non-CMS pages

### DIFF
--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -291,7 +291,7 @@ class PageToolbar(CMSToolbar):
         else:
             publish_permission = False
 
-        if publish_permission and self.statics:
+        if self.statics:
             publish_permission = all(sp.has_publish_permission(self.request) for sp in self.dirty_statics)
         return publish_permission
 


### PR DESCRIPTION
The `PageToolbar.has_publish_permission` function always returns `False` when not on CMS pages. This is incorrect as static placeholders can be placed outside of CMS pages. This fix allows for proper static placeholder publication checking as (probably) originally intended.

### Summary

<!-- If this is a security-related patch stop right here and email security@django-cms.org instead -->

Fixes #



### Links to related discussion



### Proposed changes in this pull request
